### PR TITLE
feat: elevate reading experience and rendering craft to pro level

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,10 @@ All URLs use trailing slashes (enforced in `astro.config.mjs`).
 
 `src/lib/content.ts` — Pagination helpers, post path builders, reading time calculator.
 
+`src/lib/enhance-content.ts` — Build-time enrichment of Ghost HTML (cheerio): heading ids + anchor links + TOC extraction, lazy/responsive images, hardened external links, code blocks wrapped in copyable "code frames". Applied in `PostArticle` (posts, with TOC) and `ArticleContent` (Ghost pages).
+
+`src/lib/images.ts` — Ghost image-resizing srcset builder (`/content/images/size/wNNN/` URLs).
+
 `src/lib/site.ts` — Canonical URL construction from `SITEURL`.
 
 ### Component Organisation

--- a/src/components/meta/MetaData.astro
+++ b/src/components/meta/MetaData.astro
@@ -25,6 +25,7 @@ const publisherLogo = withSiteUrl(settings.logo || siteConfig.siteIcon);
 
 const postTags = post ? getPublicTags(post.tags).map((item) => item.name) : [];
 const primaryTag = postTags[0] || '';
+const primaryAuthor = post?.authors?.[0]?.name || null;
 
 const pageType = tag ? 'Series' : 'WebSite';
 const pageTitleFromEntity = page?.title || tag?.name;
@@ -66,6 +67,12 @@ const articleJsonLd = post
       url: canonical,
       datePublished: post.published_at,
       dateModified: post.updated_at,
+      author: primaryAuthor
+        ? {
+            '@type': 'Person',
+            name: primaryAuthor,
+          }
+        : undefined,
       image: shareImage
         ? {
             '@type': 'ImageObject',

--- a/src/lib/enhance-content.ts
+++ b/src/lib/enhance-content.ts
@@ -29,6 +29,24 @@ const mergeRel = (existing: string | undefined, additions: string[]) => {
   return Array.from(tokens).join(' ');
 };
 
+const SITE_ORIGIN = new URL(`${siteUrl}/`).origin;
+
+/* Origin comparison, not prefix — a lookalike host such as
+   https://example.com.evil.tld would pass a startsWith(siteUrl) test.
+   Unparseable absolute URLs are treated as external so they still
+   get hardened. */
+const isExternalUrl = (href: string) => {
+  if (!/^https?:\/\//i.test(href)) {
+    return false;
+  }
+
+  try {
+    return new URL(href).origin !== SITE_ORIGIN;
+  } catch {
+    return true;
+  }
+};
+
 /**
  * Build-time enrichment of Ghost HTML: anchored headings + TOC data,
  * lazy responsive images, hardened external links, and code blocks
@@ -102,7 +120,7 @@ export const enhanceContent = (html?: string | null): EnhancedContent => {
     const $link = $(element);
     const href = $link.attr('href') || '';
 
-    if (/^https?:\/\//i.test(href) && !href.startsWith(siteUrl)) {
+    if (isExternalUrl(href)) {
       $link.attr('target', '_blank');
       $link.attr('rel', mergeRel($link.attr('rel'), ['noopener', 'noreferrer']));
     }

--- a/src/lib/enhance-content.ts
+++ b/src/lib/enhance-content.ts
@@ -1,0 +1,133 @@
+import { load } from 'cheerio';
+import { buildGhostSrcset } from './images';
+import { siteUrl } from './site';
+
+export interface TocEntry {
+  id: string;
+  text: string;
+  level: 2 | 3;
+}
+
+export interface EnhancedContent {
+  html: string;
+  toc: TocEntry[];
+}
+
+const CONTENT_IMAGE_SIZES = '(max-width: 720px) 100vw, 720px';
+
+const slugifyHeading = (text: string) =>
+  text
+    .toLowerCase()
+    .trim()
+    .replace(/['’]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'section';
+
+const mergeRel = (existing: string | undefined, additions: string[]) => {
+  const tokens = new Set((existing || '').split(/\s+/).filter(Boolean));
+  additions.forEach((token) => tokens.add(token));
+  return Array.from(tokens).join(' ');
+};
+
+/**
+ * Build-time enrichment of Ghost HTML: anchored headings + TOC data,
+ * lazy responsive images, hardened external links, and code blocks
+ * wrapped in a terminal-style frame with a copy affordance.
+ */
+export const enhanceContent = (html?: string | null): EnhancedContent => {
+  if (!html) {
+    return { html: '', toc: [] };
+  }
+
+  const $ = load(html);
+  const toc: TocEntry[] = [];
+  const usedIds = new Set<string>();
+
+  const claimId = (candidate: string) => {
+    let id = candidate;
+    let suffix = 2;
+
+    while (usedIds.has(id)) {
+      id = `${candidate}-${suffix}`;
+      suffix += 1;
+    }
+
+    usedIds.add(id);
+    return id;
+  };
+
+  $('h2, h3').each((_, element) => {
+    const $heading = $(element);
+    const text = $heading.text().replace(/\s+/g, ' ').trim();
+
+    if (!text) {
+      return;
+    }
+
+    const id = claimId($heading.attr('id') || slugifyHeading(text));
+    $heading.attr('id', id);
+
+    const level = element.tagName.toLowerCase() === 'h2' ? 2 : 3;
+    toc.push({ id, text, level });
+
+    const anchor = $('<a class="heading-anchor" aria-hidden="true" tabindex="-1">#</a>').attr(
+      'href',
+      `#${id}`,
+    );
+    $heading.append(anchor);
+  });
+
+  $('img').each((_, element) => {
+    const $image = $(element);
+
+    if (!$image.attr('loading')) {
+      $image.attr('loading', 'lazy');
+    }
+
+    $image.attr('decoding', 'async');
+
+    const src = $image.attr('src');
+
+    if (src && !$image.attr('srcset')) {
+      const srcset = buildGhostSrcset(src);
+
+      if (srcset) {
+        $image.attr('srcset', srcset);
+        $image.attr('sizes', $image.attr('sizes') || CONTENT_IMAGE_SIZES);
+      }
+    }
+  });
+
+  $('a[href]').each((_, element) => {
+    const $link = $(element);
+    const href = $link.attr('href') || '';
+
+    if (/^https?:\/\//i.test(href) && !href.startsWith(siteUrl)) {
+      $link.attr('target', '_blank');
+      $link.attr('rel', mergeRel($link.attr('rel'), ['noopener', 'noreferrer']));
+    }
+  });
+
+  $('pre').each((_, element) => {
+    const $pre = $(element);
+
+    if ($pre.parents('.code-frame').length > 0) {
+      return;
+    }
+
+    const classAttr = `${$pre.attr('class') || ''} ${$pre.children('code').attr('class') || ''}`;
+    const langMatch = classAttr.match(/language-([\w-]+)/);
+    const lang = langMatch ? langMatch[1] : 'code';
+
+    $pre.wrap('<div class="code-frame"></div>');
+    $pre.before(
+      `<div class="code-frame-bar">` +
+        `<span class="code-frame-dots" aria-hidden="true"><i></i><i></i><i></i></span>` +
+        `<span class="code-frame-lang">${lang}</span>` +
+        `<button type="button" class="code-frame-copy" aria-label="Copy code to clipboard">copy</button>` +
+        `</div>`,
+    );
+  });
+
+  return { html: $('body').html() || '', toc };
+};

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -1,0 +1,24 @@
+const GHOST_IMAGE_SEGMENT = '/content/images/';
+
+/* Widths matching Ghost's default theme image_sizes config — unknown
+   sizes make Ghost redirect to the original, so this degrades safely. */
+export const GHOST_IMAGE_WIDTHS = [300, 600, 1000, 2000];
+
+export const isResizableGhostImage = (url: string) =>
+  url.includes(GHOST_IMAGE_SEGMENT) &&
+  !url.includes(`${GHOST_IMAGE_SEGMENT}size/`) &&
+  !/\.(svg|gif)(\?|#|$)/i.test(url);
+
+export const ghostImageAtWidth = (url: string, width: number) =>
+  url.replace(GHOST_IMAGE_SEGMENT, `${GHOST_IMAGE_SEGMENT}size/w${width}/`);
+
+export const buildGhostSrcset = (
+  url?: string | null,
+  widths: number[] = GHOST_IMAGE_WIDTHS,
+): string | null => {
+  if (!url || !isResizableGhostImage(url)) {
+    return null;
+  }
+
+  return widths.map((width) => `${ghostImageAtWidth(url, width)} ${width}w`).join(', ');
+};

--- a/src/lib/transitions.ts
+++ b/src/lib/transitions.ts
@@ -1,0 +1,8 @@
+import type { GhostPost } from './ghost-types';
+
+/* view-transition-name must be a valid CSS custom-ident; the prefix
+   keeps names starting with a letter even for numeric slugs. */
+const getPostTransitionName = (post: GhostPost) =>
+  `post-media-${post.slug.replace(/[^a-zA-Z0-9_-]/g, '')}`;
+
+export default getPostTransitionName;

--- a/src/pages/[tag]/[slug].astro
+++ b/src/pages/[tag]/[slug].astro
@@ -20,11 +20,16 @@ export async function getStaticPaths() {
 const { tag, slug } = Astro.params;
 const settings = await getGhostSettings();
 const posts = await getAllPosts();
-const post = posts.find((item) => item.slug === slug && getPostTagSlug(item) === tag);
+const postIndex = posts.findIndex((item) => item.slug === slug && getPostTagSlug(item) === tag);
+const post = postIndex >= 0 ? posts[postIndex] : undefined;
 
 if (!post) {
   throw new Error(`Unable to find Ghost post for route /${tag}/${slug}/`);
 }
+
+// Posts are sorted newest-first, so the previous index is the newer post.
+const newerPost = postIndex > 0 ? posts[postIndex - 1] : null;
+const olderPost = postIndex < posts.length - 1 ? posts[postIndex + 1] : null;
 
 const currentPath = `/${tag}/${slug}/`;
 const canonical = canonicalFromPath(currentPath);
@@ -42,6 +47,6 @@ const canonical = canonicalFromPath(currentPath);
   </Fragment>
 
   <div class='container'>
-    <PostArticle post={post} />
+    <PostArticle post={post} newerPost={newerPost} olderPost={olderPost} />
   </div>
 </Layout>

--- a/src/ui/foundations/base.scss
+++ b/src/ui/foundations/base.scss
@@ -10,7 +10,21 @@ html {
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
+@media (prefers-reduced-motion: no-preference) {
+    html {
+        scroll-behavior: smooth;
+    }
+}
+
+/* Anchored sections land clear of the sticky header */
+:where([id]) {
+    scroll-margin-top: calc(var(--header-height) + var(--space-lg));
+}
+
 body {
+    /* hidden turns body into a scroll container, which silently kills
+       position: sticky and scroll-driven timelines for every descendant;
+       clip crops horizontal overflow without doing that */
     overflow-x: hidden;
     color: var(--color-text-primary);
     font-family: var(--font-family-sans);
@@ -25,6 +39,12 @@ body {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     -moz-font-feature-settings: "liga" on;
+}
+
+@supports (overflow-x: clip) {
+    body {
+        overflow-x: clip;
+    }
 }
 
 ::selection {

--- a/src/ui/foundations/reset.scss
+++ b/src/ui/foundations/reset.scss
@@ -123,6 +123,9 @@ table {
 
 img {
     max-width: 100%;
+    /* Keep the intrinsic ratio when width/height attributes are
+       present and max-width kicks in */
+    height: auto;
 }
 
 html {

--- a/src/ui/layout/ArticleContent.astro
+++ b/src/ui/layout/ArticleContent.astro
@@ -1,4 +1,6 @@
 ---
+import { enhanceContent } from '../../lib/enhance-content';
+
 interface Props {
   title: string;
   html?: string | null;
@@ -7,13 +9,14 @@ interface Props {
 
 const { title, html = null, centered = false } = Astro.props;
 const articleClass = centered ? 'content content-centered' : 'content';
+const enhancedHtml = html !== null ? enhanceContent(html).html : null;
 ---
 
 <article class={articleClass}>
   <h1 class='content-title'>{title}</h1>
   {
-    html !== null ? (
-      <section class='content-body load-external-scripts' set:html={html} />
+    enhancedHtml !== null ? (
+      <section class='content-body load-external-scripts' set:html={enhancedHtml} />
     ) : (
       <section class='content-body'>
         <slot />

--- a/src/ui/layout/Layout.astro
+++ b/src/ui/layout/Layout.astro
@@ -47,6 +47,8 @@ const currentYear = new Date().getFullYear();
     <meta name='viewport' content='width=device-width,initial-scale=1' />
     <link rel='icon' href='/favicon.png' />
     <link rel='manifest' href='/manifest.webmanifest' />
+    <link rel='alternate' type='application/rss+xml' title={settings.title} href='/rss/' />
+    <link rel='sitemap' href='/sitemap-index.xml' />
     <meta name='theme-color' content='#0e0918' />
     <script is:inline>
       (() => {
@@ -107,8 +109,38 @@ const currentYear = new Date().getFullYear();
 
         const height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
         const scrollTop = document.body.scrollTop || document.documentElement.scrollTop;
-        progress.style.width = `${(scrollTop / height) * 100}%`;
+        const ratio = height > 0 ? Math.min(1, Math.max(0, scrollTop / height)) : 0;
+        // scaleX instead of width keeps the update off the layout pass
+        progress.style.transform = `scaleX(${ratio})`;
       };
+
+      // Copy buttons on build-time code frames — delegated so it
+      // covers posts and Ghost pages alike, and stays inert elsewhere.
+      const resetTimers = new WeakMap<HTMLElement, number>();
+      document.addEventListener('click', (event) => {
+        const target = event.target as HTMLElement | null;
+        const button = target?.closest<HTMLButtonElement>('.code-frame-copy');
+        if (!button) return;
+
+        const code = button.closest('.code-frame')?.querySelector('pre');
+        if (!code) return;
+
+        navigator.clipboard
+          .writeText(code.innerText.replace(/\n$/, ''))
+          .then(() => {
+            button.textContent = 'copied ✓';
+            button.dataset.copied = 'true';
+            window.clearTimeout(resetTimers.get(button));
+            resetTimers.set(
+              button,
+              window.setTimeout(() => {
+                button.textContent = 'copy';
+                delete button.dataset.copied;
+              }, 2000),
+            );
+          })
+          .catch(() => {});
+      });
 
       window.addEventListener('scroll', setScrollProgress, { passive: true });
       window.addEventListener('load', () => {

--- a/src/ui/layout/PostArticle.astro
+++ b/src/ui/layout/PostArticle.astro
@@ -1,12 +1,17 @@
 ---
 import type { GhostPost } from '../../lib/ghost-types';
-import { formatReadingTime, getPublicTags } from '../../lib/content';
+import { formatReadingTime, getPostPath, getPublicTags } from '../../lib/content';
+import { enhanceContent } from '../../lib/enhance-content';
+import { buildGhostSrcset } from '../../lib/images';
+import getPostTransitionName from '../../lib/transitions';
 
 interface Props {
   post: GhostPost;
+  newerPost?: GhostPost | null;
+  olderPost?: GhostPost | null;
 }
 
-const { post } = Astro.props;
+const { post, newerPost = null, olderPost = null } = Astro.props;
 
 const publicTags = getPublicTags(post.tags);
 const primaryTag = publicTags[0] || null;
@@ -19,6 +24,20 @@ const publishedDate = post.published_at
     })
   : null;
 const publishedDateTime = post.published_at ? post.published_at.slice(0, 10) : null;
+
+const { html, toc } = enhanceContent(post.html);
+const showToc = toc.length >= 3;
+const featureSrcset = buildGhostSrcset(post.feature_image);
+const transitionName = getPostTransitionName(post);
+
+const formatNavDate = (navPost: GhostPost) =>
+  navPost.published_at
+    ? new Date(navPost.published_at).toLocaleDateString('en-GB', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+      })
+    : null;
 ---
 
 <div id='scroll-progress' aria-hidden='true'></div>
@@ -40,20 +59,192 @@ const publishedDateTime = post.published_at ? post.published_at.slice(0, 10) : n
   {
     post.feature_image && (
       <figure class='post-feature'>
-        <img src={post.feature_image} alt='' loading='eager' decoding='async' />
+        <img
+          src={post.feature_image}
+          srcset={featureSrcset}
+          sizes={featureSrcset ? '(max-width: 980px) 100vw, 920px' : undefined}
+          alt=''
+          loading='eager'
+          fetchpriority='high'
+          decoding='async'
+          style={`view-transition-name: ${transitionName};`}
+        />
       </figure>
     )
   }
 
-  <section class='post-full-content'>
-    <section class='content-body load-external-scripts' set:html={post.html} />
-  </section>
+  <div class='post-body'>
+    {
+      showToc && (
+        <nav class='post-toc' data-toc aria-label='Table of contents'>
+          <div class='post-toc-inner'>
+            <p class='post-toc-label spec-label' aria-hidden='true'>
+              [ on this page ]
+            </p>
+            <ol class='post-toc-list'>
+              {toc.map((entry) => (
+                <li class={`post-toc-item post-toc-item--h${entry.level}`}>
+                  <a class='post-toc-link' href={`#${entry.id}`}>
+                    {entry.text}
+                  </a>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </nav>
+      )
+    }
+
+    <section class='post-full-content'>
+      <section class='content-body load-external-scripts' set:html={html} />
+    </section>
+  </div>
 
   <footer class='post-end'>
     <span class='spec-label'>// EOF</span>
-    <a class='post-end-back spec-label' href='/'>&lt;- back to index</a>
+    <div class='post-end-actions'>
+      <button type='button' class='post-end-share spec-label' data-copy-link>
+        [ copy link ]
+      </button>
+      <a class='post-end-back spec-label' href='/'>&lt;- back to index</a>
+    </div>
   </footer>
+
+  {
+    (newerPost || olderPost) && (
+      <nav class='post-nav' aria-label='Adjacent posts'>
+        {olderPost ? (
+          <a class='post-nav-link post-nav-link--older' href={getPostPath(olderPost)}>
+            <span class='spec-label post-nav-direction'>
+              <span aria-hidden='true'>&lt;- </span>older transmission
+            </span>
+            <span class='post-nav-title'>{olderPost.title}</span>
+            {formatNavDate(olderPost) && (
+              <span class='spec-label post-nav-date'>{formatNavDate(olderPost)}</span>
+            )}
+          </a>
+        ) : (
+          <span class='post-nav-spacer' aria-hidden='true' />
+        )}
+        {newerPost && (
+          <a class='post-nav-link post-nav-link--newer' href={getPostPath(newerPost)}>
+            <span class='spec-label post-nav-direction'>
+              newer transmission<span aria-hidden='true'> -&gt;</span>
+            </span>
+            <span class='post-nav-title'>{newerPost.title}</span>
+            {formatNavDate(newerPost) && (
+              <span class='spec-label post-nav-date'>{formatNavDate(newerPost)}</span>
+            )}
+          </a>
+        )}
+      </nav>
+    )
+  }
 </article>
+
+<script>
+  // Scrollspy — highlight the TOC entry for the section in view.
+  (() => {
+    const toc = document.querySelector<HTMLElement>('[data-toc]');
+    if (!toc) return;
+
+    const links = Array.from(toc.querySelectorAll<HTMLAnchorElement>('a[href^="#"]'));
+    const pairs = links
+      .map((link) => {
+        const target = document.getElementById(decodeURIComponent(link.hash.slice(1)));
+        return target ? { link, target } : null;
+      })
+      .filter((pair): pair is { link: HTMLAnchorElement; target: HTMLElement } => pair !== null);
+
+    if (pairs.length === 0) return;
+
+    let offsets: number[] = [];
+    let activeLink: HTMLAnchorElement | null = null;
+    let frame = 0;
+
+    const measure = () => {
+      offsets = pairs.map(({ target }) => target.getBoundingClientRect().top + window.scrollY);
+    };
+
+    const activate = (link: HTMLAnchorElement | null) => {
+      if (link === activeLink) return;
+
+      activeLink?.classList.remove('is-active');
+      activeLink?.removeAttribute('aria-current');
+      link?.classList.add('is-active');
+      link?.setAttribute('aria-current', 'true');
+      activeLink = link;
+    };
+
+    const update = () => {
+      // Reading line sits a third down the viewport — feels closest to
+      // "the section I am actually reading" at typical scroll positions.
+      const line = window.scrollY + window.innerHeight * 0.33;
+      let current: HTMLAnchorElement | null = null;
+
+      for (let i = 0; i < offsets.length; i += 1) {
+        if (offsets[i] <= line) {
+          current = pairs[i].link;
+        } else {
+          break;
+        }
+      }
+
+      activate(current);
+    };
+
+    const requestUpdate = () => {
+      if (frame) return;
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        update();
+      });
+    };
+
+    const remeasure = () => {
+      measure();
+      requestUpdate();
+    };
+
+    window.addEventListener('scroll', requestUpdate, { passive: true });
+    window.addEventListener('resize', remeasure);
+    window.addEventListener('load', remeasure);
+
+    // Lazy media loading shifts heading offsets as it lands.
+    const observer = new ResizeObserver(remeasure);
+    const body = document.querySelector('.content-body');
+    if (body) observer.observe(body);
+
+    remeasure();
+  })();
+
+  // Copy the canonical article URL from the EOF row.
+  (() => {
+    const button = document.querySelector<HTMLButtonElement>('[data-copy-link]');
+    if (!button) return;
+
+    const idleLabel = button.textContent || '[ copy link ]';
+    let resetTimer = 0;
+
+    button.addEventListener('click', async () => {
+      const url = window.location.origin + window.location.pathname;
+
+      try {
+        await navigator.clipboard.writeText(url);
+        button.textContent = '[ copied ✓ ]';
+        button.dataset.copied = 'true';
+      } catch {
+        button.textContent = '[ copy failed ]';
+      }
+
+      window.clearTimeout(resetTimer);
+      resetTimer = window.setTimeout(() => {
+        button.textContent = idleLabel;
+        delete button.dataset.copied;
+      }, 2000);
+    });
+  })();
+</script>
 
 <style is:global lang='scss'>
   @use '../styles/content-typography' as content;

--- a/src/ui/layout/SiteHeader.astro
+++ b/src/ui/layout/SiteHeader.astro
@@ -48,6 +48,9 @@ const { settings, currentPath, isHome = false } = Astro.props;
     border-bottom: 1px solid var(--glass-border);
     backdrop-filter: blur(var(--blur-glass)) saturate(1.5);
     -webkit-backdrop-filter: blur(var(--blur-glass)) saturate(1.5);
+    /* Own transition group — the chrome stays put while page content
+       morphs during cross-document view transitions */
+    view-transition-name: site-head;
   }
 
   /* Bar starts transparent and frosts over as you scroll —

--- a/src/ui/posts/PostCard.astro
+++ b/src/ui/posts/PostCard.astro
@@ -1,6 +1,8 @@
 ---
 import type { GhostPost } from '../../lib/ghost-types';
 import { formatReadingTime, getPostPath, getPublicTags } from '../../lib/content';
+import getPostTransitionName from '../../lib/transitions';
+import { buildGhostSrcset } from '../../lib/images';
 
 interface Props {
   post: GhostPost;
@@ -23,16 +25,32 @@ const publishedDate = post.published_at
       year: 'numeric',
     })
   : null;
+
+const isFeature = variant === 'feature';
+const imageSrcset = buildGhostSrcset(post.feature_image);
+const imageSizes = isFeature
+  ? '(max-width: 980px) 100vw, 640px'
+  : '(max-width: 680px) 100vw, (max-width: 980px) 92vw, 560px';
+const transitionName = getPostTransitionName(post);
 ---
 
 <a href={url} class={`post-card ${variant === 'feature' ? 'post-card--feature' : ''}`}>
   <span class='post-card-corner post-card-corner--tl' aria-hidden='true'></span>
   <span class='post-card-corner post-card-corner--br' aria-hidden='true'></span>
 
-  <div class='post-card-media'>
+  <div class='post-card-media' style={`view-transition-name: ${transitionName};`}>
     {
       post.feature_image ? (
-        <div class='post-card-image' style={`background-image: url(${post.feature_image});`} />
+        <img
+          class='post-card-image'
+          src={post.feature_image}
+          srcset={imageSrcset}
+          sizes={imageSrcset ? imageSizes : undefined}
+          alt=''
+          loading={isFeature ? 'eager' : 'lazy'}
+          fetchpriority={isFeature ? 'high' : undefined}
+          decoding='async'
+        />
       ) : (
         <div class='post-card-placeholder' aria-hidden='true'>
           <span class='post-card-placeholder-index'>{indexLabel}</span>
@@ -134,9 +152,10 @@ const publishedDate = post.published_at
   .post-card-image {
     position: absolute;
     inset: 0;
-    background-position: center;
-    background-size: cover;
-    background-repeat: no-repeat;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 0;
     background-color: var(--color-surface-muted);
     transition:
       transform var(--transition-slow),

--- a/src/ui/styles/_content-typography.scss
+++ b/src/ui/styles/_content-typography.scss
@@ -163,6 +163,23 @@
       border-radius: var(--radius-md);
     }
 
+    /* Deep links appear on heading hover; sighted keyboard and AT
+       users navigate by heading instead, so the glyph stays hidden */
+    .heading-anchor {
+      margin-left: 0.4em;
+      font-family: var(--font-family-mono);
+      font-size: 0.7em;
+      font-weight: var(--font-weight-normal);
+      color: var(--color-accent-text);
+      text-decoration: none;
+      opacity: 0;
+      transition: opacity var(--transition-fast);
+    }
+
+    :is(h2, h3):hover .heading-anchor {
+      opacity: 1;
+    }
+
     pre {
       margin: var(--space-sm) 0 var(--space-lg);
       padding: var(--space-md) var(--space-lg);
@@ -176,6 +193,91 @@
       color: var(--code-text);
       border-radius: var(--radius-lg);
       box-shadow: var(--shadow-sm);
+    }
+
+    /* Terminal frame around code blocks — bar with language chip
+       and copy action, injected at build time */
+    .code-frame {
+      margin: var(--space-sm) 0 var(--space-lg);
+      border: 1px solid var(--code-border);
+      border-radius: var(--radius-lg);
+      background: var(--code-bg);
+      box-shadow: var(--shadow-sm);
+      overflow: clip;
+
+      pre {
+        margin: 0;
+        border: 0;
+        border-radius: 0;
+        box-shadow: none;
+      }
+    }
+
+    .code-frame-bar {
+      display: flex;
+      align-items: center;
+      gap: var(--space-sm);
+      padding: var(--space-2xs) var(--space-sm) var(--space-2xs) var(--space-md);
+      border-bottom: 1px solid var(--code-border);
+    }
+
+    .code-frame-dots {
+      display: inline-flex;
+      gap: 0.55rem;
+
+      i {
+        width: 0.9rem;
+        height: 0.9rem;
+        border-radius: 50%;
+
+        &:nth-child(1) {
+          background: color-mix(in srgb, var(--color-pink-500) 75%, transparent);
+        }
+
+        &:nth-child(2) {
+          background: color-mix(in srgb, var(--color-violet-500) 75%, transparent);
+        }
+
+        &:nth-child(3) {
+          background: color-mix(in srgb, var(--color-cyan-500) 75%, transparent);
+        }
+      }
+    }
+
+    .code-frame-lang {
+      font-family: var(--font-family-mono);
+      font-size: var(--text-2xs);
+      letter-spacing: var(--letter-spacing-mono);
+      text-transform: uppercase;
+      color: var(--code-comment);
+    }
+
+    .code-frame-copy {
+      margin-left: auto;
+      padding: 0.2rem 1.1rem;
+      font-family: var(--font-family-mono);
+      font-size: var(--text-2xs);
+      letter-spacing: var(--letter-spacing-mono);
+      text-transform: uppercase;
+      color: var(--code-comment);
+      background: none;
+      border: 1px solid var(--code-border);
+      border-radius: var(--radius-full);
+      cursor: pointer;
+      transition:
+        color var(--transition-fast),
+        border-color var(--transition-fast),
+        box-shadow var(--transition-fast);
+
+      &:hover {
+        color: var(--color-accent-text);
+        border-color: color-mix(in srgb, var(--color-accent) 55%, var(--code-border));
+      }
+
+      &[data-copied='true'] {
+        color: var(--color-accent-2-text);
+        border-color: color-mix(in srgb, var(--color-accent-2) 55%, var(--code-border));
+      }
     }
 
     pre code {

--- a/src/ui/styles/_post-shell.scss
+++ b/src/ui/styles/_post-shell.scss
@@ -3,11 +3,13 @@
     position: fixed;
     top: 0;
     left: 0;
-    width: 0;
+    width: 100%;
     height: 3px;
     background: linear-gradient(90deg, var(--color-accent), var(--color-accent-2));
     box-shadow: var(--glow-pink);
     z-index: var(--z-progress);
+    transform: scaleX(0);
+    transform-origin: 0 50%;
   }
 
   .post-article {
@@ -34,7 +36,8 @@
   }
 
   /* Feature image — breaks out wider than the reading column,
-     framed by offset chromatic plates */
+     framed by offset chromatic plates. Fixed aspect ratio keeps the
+     editorial crop consistent and reserves space before load. */
   .post-feature {
     position: relative;
     width: 100%;
@@ -43,6 +46,7 @@
 
     img {
       width: 100%;
+      aspect-ratio: 16 / 9;
       max-height: 52rem;
       object-fit: cover;
       display: block;
@@ -74,10 +78,102 @@
     }
   }
 
+  .post-body {
+    position: relative;
+    width: 100%;
+  }
+
   .post-full-content {
     width: 100%;
     max-width: var(--layout-width-reading);
     margin: 0 auto;
+  }
+
+  /* Table of contents — a sticky rail floating beside the reading
+     column. Anchored off the column's centre so the measure itself
+     never shifts; hidden until there is honest room for it. */
+  .post-toc {
+    display: none;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: calc(50% + (var(--layout-width-reading) / 2) + var(--space-2xl));
+    width: 22rem;
+  }
+
+  @media (min-width: 1280px) {
+    .post-toc {
+      display: block;
+    }
+  }
+
+  .post-toc-inner {
+    position: sticky;
+    top: calc(var(--header-height) + var(--space-lg));
+    max-height: calc(100vh - var(--header-height) - var(--space-2xl));
+    overflow-y: auto;
+    scrollbar-width: thin;
+  }
+
+  .post-toc-label {
+    margin: 0 0 var(--space-sm);
+  }
+
+  .post-toc-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    border-left: 1px solid var(--color-border-subtle);
+  }
+
+  .post-toc-item {
+    margin: 0;
+    padding: 0;
+
+    &--h3 .post-toc-link {
+      padding-left: var(--space-md);
+    }
+  }
+
+  .post-toc-link {
+    position: relative;
+    display: block;
+    padding: var(--space-3xs) 0 var(--space-3xs) var(--space-sm);
+    font-size: var(--text-sm);
+    line-height: var(--leading-snug);
+    color: var(--color-text-muted);
+    text-decoration: none;
+    transition: color var(--transition-fast);
+
+    /* Marker line riding the rail's left border */
+    &::before {
+      content: '';
+      position: absolute;
+      left: -1px;
+      top: 0.4rem;
+      bottom: 0.4rem;
+      width: 2px;
+      background: var(--color-accent);
+      opacity: 0;
+      transform: scaleY(0.4);
+      transition:
+        opacity var(--transition-fast),
+        transform var(--transition-fast);
+    }
+
+    &:hover {
+      color: var(--color-text-primary);
+      text-decoration: none;
+    }
+
+    &.is-active {
+      color: var(--color-accent-text);
+
+      &::before {
+        opacity: 1;
+        transform: scaleY(1);
+      }
+    }
   }
 
   .post-end {
@@ -92,6 +188,29 @@
     border-top: 1px solid var(--color-border-subtle);
   }
 
+  .post-end-actions {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-md);
+  }
+
+  .post-end-share {
+    padding: 0;
+    border: 0;
+    background: none;
+    cursor: pointer;
+    color: var(--color-accent-2-text);
+    transition: color var(--transition-fast);
+
+    &:hover {
+      color: var(--color-link-hover);
+    }
+
+    &[data-copied='true'] {
+      color: var(--color-accent-2-text);
+    }
+  }
+
   .post-end-back {
     color: var(--color-accent-text);
     transition: color var(--transition-fast);
@@ -102,12 +221,94 @@
     }
   }
 
+  /* Adjacent posts — keep the reader moving through the archive */
+  .post-nav {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-md);
+    width: 100%;
+    max-width: var(--layout-width-reading);
+    margin: var(--space-lg) auto 0;
+  }
+
+  .post-nav-link {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2xs);
+    padding: var(--space-md);
+    color: inherit;
+    text-decoration: none;
+    background: color-mix(in srgb, var(--color-surface-raised) 88%, transparent);
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--radius-lg);
+    transition:
+      transform var(--transition-medium),
+      border-color var(--transition-medium),
+      box-shadow var(--transition-medium);
+
+    &:hover {
+      color: inherit;
+      text-decoration: none;
+      transform: translateY(-0.3rem);
+      border-color: color-mix(in srgb, var(--color-accent) 45%, var(--color-border-subtle));
+      box-shadow: var(--shadow-md), var(--glow-pink);
+    }
+
+    &--newer {
+      align-items: flex-end;
+      text-align: right;
+    }
+  }
+
+  .post-nav-direction {
+    color: var(--color-accent-text);
+  }
+
+  .post-nav-title {
+    font-family: var(--font-family-display);
+    font-size: var(--text-lg);
+    font-weight: var(--font-weight-bold);
+    line-height: var(--leading-snug);
+    letter-spacing: var(--letter-spacing-display);
+    color: var(--color-text-strong);
+    text-wrap: balance;
+  }
+
+  .post-nav-date {
+    margin-top: auto;
+    padding-top: var(--space-2xs);
+  }
+
   @media (max-width: 680px) {
     .post-feature {
       &::before,
       &::after {
         display: none;
       }
+    }
+
+    .post-end {
+      flex-wrap: wrap;
+    }
+
+    .post-nav {
+      grid-template-columns: 1fr;
+    }
+
+    .post-nav-link--newer {
+      align-items: flex-start;
+      text-align: left;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .post-toc-link,
+    .post-nav-link {
+      transition: none;
+    }
+
+    .post-nav-link:hover {
+      transform: none;
     }
   }
 }


### PR DESCRIPTION
Build-time content enhancement (cheerio, no client framework cost):
- Heading ids + hover anchor links and TOC extraction from post HTML
- Lazy, responsive content images via Ghost's resize endpoint srcsets
- External links hardened with target=_blank + noopener noreferrer
- Code blocks wrapped in terminal-style frames with language chip and
  a delegated copy-to-clipboard action

Article page:
- Sticky "[ on this page ]" TOC rail beside the reading column with a
  rAF scrollspy (active section marker, aria-current)
- Older/newer transmission cards keep readers moving through the archive
- Copy-link action in the EOF row with copied feedback
- Feature image gets srcset + fetchpriority=high and a fixed 16:9 crop
  so the layout never shifts

Feed and navigation:
- PostCard media is now a real <img> with srcset/sizes, lazy for grid
  cards and eager + fetchpriority=high for the feature card
- Per-post view-transition-name morphs the card image into the article
  feature image on navigation; the site header holds its own transition
  group so chrome stays stable

Fixes uncovered while verifying:
- body { overflow-x: hidden } made <body> a scroll container, silently
  breaking every position: sticky element and scroll-driven timeline;
  progressively replaced with overflow-x: clip
- img { max-width: 100% } without height: auto distorted/letterboxed
  content images carrying width/height attributes
- Scroll progress bar now animates transform: scaleX instead of width,
  keeping updates off the layout pass

Also: RSS + sitemap discovery links, smooth scrolling with anchored
sections clearing the sticky header, Article JSON-LD author, and
CLAUDE.md notes for the new data-layer modules.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018pRrJro2HVfj9uToNKdQwJ